### PR TITLE
Fixed a bug preventing the system from locking.

### DIFF
--- a/Src/DPLLv2.v
+++ b/Src/DPLLv2.v
@@ -297,8 +297,8 @@ begin
     if(Rst_Err)
         Err <= #1 0;
     else if(CE_Err)
-        Err <= #1 Err + ((xPPS | Up) ? pPosFreqPhiBase
-                                     : (iPPS | Dn) ? pNegFreqPhiBase : 0);
+        Err <= #1 Err + (((xPPS | Up) & ~(iPPS | Dn)) ? pPosFreqPhiBase :
+						((iPPS | Dn) & ~(xPPS | Up)) ? pNegFreqPhiBase : 0);
 end
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/Src/DPLLv2.v
+++ b/Src/DPLLv2.v
@@ -129,7 +129,7 @@ module DPLLv2 #(
     output  reg ErrLim,         // Allowable Phase Error Limit FF
     output  reg [3:0] LockCntr, // DPLL Lock Delay Cntr
     
-    output  [31:0] Kphi,        // NCO Frequency Control Word (FCW)
+    output  reg [31:0] Kphi,    // NCO Frequency Control Word (FCW)
     output  [31:0] NCODrv,      // NCO Loop Filter Output
     output  reg [31:0] NCO      // NCO Phase Register
 );
@@ -319,7 +319,16 @@ end
 
 //  Offset nominal NCO FCW by the accumulated/integrated Phase Error
 
-assign Kphi = pBasePhaseIncrement + PhiErr;
+//assign Kphi = pBasePhaseIncrement + PhiErr;
+
+// Registered Kphi, to help meet timing with high fanout in VCODriveFilter.
+always @(posedge Clk)
+begin
+	if(Rst)
+		Kphi <= #1 pBasePhaseIncrement;
+	else
+		Kphi <= #1 pBasePhaseIncrement + PhiErr;
+end
 
 //  Filter NCO FCW before applying to NCO (DDS)
 


### PR DESCRIPTION
Added some additional checks to handle when iPPS is equal to xPPS or the case where we are asserting up and down simultaneously. In these cases, we shouldn't increment or decrement the error case. This helped with the system locking.